### PR TITLE
modified to prevent this requirements conflict

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  keycloak-flask:
+  keycloak_flask:
     restart: "unless-stopped"
     build: .
     environment:
@@ -10,6 +10,8 @@ services:
         - KEYCLOAK_FLASK_SETTINGS=local_settings.py
     ports:
       - "5000:5000"
+    networks:
+      - kitt
 
 networks:
   kitt:

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  keycloak-flask:
+    restart: "unless-stopped"
+    build: .
+    environment:
+        - FLASK_APP=keycloak_flask.user
+        - FLASK_DEBUG=1
+        - KEYCLOAK_FLASK_SETTINGS=local_settings.py
+    ports:
+      - "5000:5000"
+
+networks:
+  kitt:
+    external: true

--- a/keycloak_flask/settings.py
+++ b/keycloak_flask/settings.py
@@ -10,6 +10,7 @@ ADMIN_PASS = "admin"
 REALM_NAME = "master"
 # created in keycloak per https://github.com/keycloak/keycloak-documentation/blob/main/securing_apps/topics/client-registration/client-registration-cli.adoc
 CLIENT_ID = "keycloak-flask"
-CLIENT_SECRET = ""
+# set access-type to confidential, save, reload, will see a credentials tab where you can set this
+CLIENT_SECRET = "2da4a9a4-f6f0-48d9-82f6-12012402f03a"
 
-INGRESS_HOST = "https://www.google.com/"
+INGRESS_HOST = "http://www.google.com/"

--- a/keycloak_flask/settings.py
+++ b/keycloak_flask/settings.py
@@ -1,12 +1,15 @@
 # for local
+# It's probably helpful for us to demonstrate what the URL should be, etc.
 
-SECRET_KEY = b''
+SECRET_KEY = b'keycloak'
 
-SERVER_URL = ""
-ADMIN_USERNAME = ""
-ADMIN_PASS = ""
-REALM_NAME = ""
-CLIENT_ID = ""
+# http, not https for some reason
+SERVER_URL = "http://keycloak-idp:8080/auth/"
+ADMIN_USERNAME = "admin"
+ADMIN_PASS = "admin"
+REALM_NAME = "master"
+# created in keycloak per https://github.com/keycloak/keycloak-documentation/blob/main/securing_apps/topics/client-registration/client-registration-cli.adoc
+CLIENT_ID = "keycloak-flask"
 CLIENT_SECRET = ""
 
-INGRESS_HOST = ""
+INGRESS_HOST = "https://www.google.com/"

--- a/keycloak_flask/settings.py
+++ b/keycloak_flask/settings.py
@@ -13,4 +13,5 @@ CLIENT_ID = "keycloak-flask"
 # set access-type to confidential, save, reload, will see a credentials tab where you can set this
 CLIENT_SECRET = "2da4a9a4-f6f0-48d9-82f6-12012402f03a"
 
+# You'll probably have to tell docker this is OK on a Mac
 INGRESS_HOST = "http://www.google.com/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,11 +34,11 @@ Pygments==2.7.2
 python-jose==3.0.1
 python-jwt==3.2.4
 python-keycloak==0.17.6
-requests==2.22.0
+requests==2.26.0
 rsa==4.0
 six==1.15.0
 traitlets==4.3.3
-urllib3==1.26.2
+urllib3==1.26.7
 wcwidth==0.1.7
 Werkzeug==0.16.0
 WTForms==2.2.1


### PR DESCRIPTION
Seems there was some dependency rot, so I updated to latest.
 #8 8.850 ERROR: Cannot install -r requirements.txt (line 37) and urllib3==1.26.2 because these package versions have conflicting dependencies.
 #8 8.851
 #8 8.851 The conflict is caused by:
 #8 8.851     The user requested urllib3==1.26.2
 #8 8.851     requests 2.22.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1